### PR TITLE
[Changed] 更新 inappwebview 版本

### DIFF
--- a/packages/youtube_player_flutter/pubspec.yaml
+++ b/packages/youtube_player_flutter/pubspec.yaml
@@ -12,10 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_inappwebview:
-    git:
-      url: https://github.com/VictorUvarov/flutter_inappwebview.git
-      ref: ios-16-compile-issue
+  flutter_inappwebview: ^5.7.2+3
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Description

原本是因為 [iOS 16 compile issue](https://github.com/sarbagyastha/youtube_player_flutter/issues/709)，需要引用其他 fork 的 repository，但後來的版本已修正，所以更新為 youtube_player_flutter 現在所使用的版本：

```yaml
dependencies:
  ...
  flutter_inappwebview: ^5.7.2+3
```

測試更新後，播放器可正常執行。